### PR TITLE
Support newer versions of Astron

### DIFF
--- a/astron/dclass/tto.dc
+++ b/astron/dclass/tto.dc
@@ -410,7 +410,7 @@ dclass TimeManager : DistributedObject {
   serverTime(uint8, int32, uint32);
   setDisconnectReason(uint8) airecv clsend;
   setExceptionInfo(string(0-1024)) airecv clsend;
-  setSignature(string(0-1024), char [16], char [16]) airecv clsend;
+  setSignature(string(0-1024), blob(0-16), blob(0-16)) airecv clsend;
   setFrameRate(uint16/10, uint16/1000, uint16, string(0-256), uint32/10, uint32/10, string(0-256), uint16, uint16, uint32/10, uint32/10, uint32/10, uint32, OSInfo, CPUSpeed, uint16, uint16, string(0-256)) airecv clsend;
   setCpuInfo(string(0-1024), string) airecv clsend;
   checkForGarbageLeaks(bool) airecv clsend;


### PR DESCRIPTION
Newer versions of Astron will prevent string unpacking when the encoding is UTF-8. 

TimeManager's setSignature updates will therefore fail and prevent any user from getting past toon selection, so change the types to blob where needed.