### PR TITLE
[TTR] Fix a crash that occurs when the activeIntervals map is modified while iterating through it

### DIFF
--- a/toontown/suit/DistributedBossCog.py
+++ b/toontown/suit/DistributedBossCog.py
@@ -183,7 +183,7 @@ class DistributedBossCog(DistributedAvatar.DistributedAvatar, BossCog.BossCog):
         self.activeIntervals[name] = interval
 
     def cleanupIntervals(self):
-        for interval in self.activeIntervals.values():
+        for interval in list(self.activeIntervals.values()):
             interval.finish()
             DelayDelete.cleanupDelayDeletes(interval)
 


### PR DESCRIPTION
A frequent crash I noticed when quad craning and doing `~rcr`. It seems to crash during it due to this map being modified while it is being iterated through. 

Error is as below:
```py
    for interval in self.activeIntervals.values():
   RuntimeError: dictionary changed size during iteration
```

Solution is to iterate through a copy of it. 

One issue may be that due to the frequency with which it is called, it can have some performance impact (not investigated thoroughly).

Another may be that the other bosses are impacted negatively due to this.
